### PR TITLE
Voice picker overhaul + audio engine cleanup

### DIFF
--- a/src/lib/Caroline.ts
+++ b/src/lib/Caroline.ts
@@ -2,6 +2,7 @@ import type { INoteLyricsJSON } from './INoteLyricsJSON'
 import type { IMidiLyricsJSON } from './IMidiLyricsJSON'
 
 type ToneModule = typeof import('tone')
+type Disposable = { dispose: () => unknown }
 
 type OnWantsToSpeek = (note: INoteLyricsJSON) => void
 
@@ -14,6 +15,8 @@ export class Caroline {
   private _tone: ToneModule | null = null
   private _preloadPromise: Promise<void> | null = null
   private _onwantstospeek: OnWantsToSpeek = () => true
+  private _parts: Disposable[] = []
+  private _synths: Disposable[] = []
 
   set onwanttospeek (v: OnWantsToSpeek | undefined) {
     if (typeof v === 'undefined') {
@@ -48,7 +51,11 @@ export class Caroline {
       throw new Error('Caroline failed to preload')
     }
 
-    const { Transport, Part, Draw } = this._tone
+    this._disposeAll()
+
+    const { Transport, Part, Draw, start } = this._tone
+
+    await start()
 
     Transport.bpm.value = this._song.header.tempos[0].bpm
 
@@ -68,11 +75,13 @@ export class Caroline {
         }, track.notes)
 
         lyricsPart.start()
+        this._parts.push(lyricsPart)
 
         continue
       }
 
       const synth = this._getSynthForNote(track.instrument.name);
+      this._synths.push(synth)
 
       const songPart = new Part((time, note) => {
         try {
@@ -90,6 +99,7 @@ export class Caroline {
       }, track.notes)
 
       songPart.start();
+      this._parts.push(songPart)
     }
 
     Transport.start()
@@ -100,6 +110,14 @@ export class Caroline {
     const { Transport } = this._tone
     Transport.stop()
     Transport.cancel(0)
+    this._disposeAll()
+  }
+
+  private _disposeAll () {
+    for (const part of this._parts) part.dispose()
+    for (const synth of this._synths) synth.dispose()
+    this._parts = []
+    this._synths = []
   }
 
   private _getSynthForNote (instrument: string) {

--- a/src/lib/IMidiLyricsJSON.ts
+++ b/src/lib/IMidiLyricsJSON.ts
@@ -1,6 +1,5 @@
 import type { HeaderJSON, TrackJSON } from '@tonejs/midi';
-import type { NoteJSON } from '@tonejs/midi/dist/Note';
-import type { INoteLyricsJSON } from './INoteLyricsJSON';
+import type { INoteLyricsJSON, NoteJSON } from './INoteLyricsJSON';
 
 export interface IMidiLyricsJSON {
   header: HeaderJSON;

--- a/src/lib/INoteLyricsJSON.ts
+++ b/src/lib/INoteLyricsJSON.ts
@@ -1,4 +1,12 @@
-import type { NoteJSON } from '@tonejs/midi/dist/Note'
+export interface NoteJSON {
+  time: number
+  midi: number
+  name: string
+  velocity: number
+  duration: number
+  ticks: number
+  durationTicks: number
+}
 
 export interface INoteLyricsJSON extends NoteJSON {
   text: string

--- a/src/lib/Sam.ts
+++ b/src/lib/Sam.ts
@@ -10,7 +10,6 @@ export class Sam {
   private _voice: SpeechSynthesisVoice | null = null
   private _broken = false // true if speechSynthesis can't be accessed
   private _onvoiceschanged: OnVoicesChanged = () => true
-  private _voices: SpeechSynthesisVoice[] = []
 
   set onvoiceschanged (v: OnVoicesChanged | undefined) {
     if (this._broken) {
@@ -56,9 +55,7 @@ export class Sam {
   }
 
   updateVoices () {
-    this._voices = this._speech.getVoices();
-
-    this._onvoiceschanged.call(this, this._voices);
+    this._onvoiceschanged.call(this, this._speech.getVoices());
   }
 
   saySentence (sentence: string) {

--- a/src/lib/components/ControlButton.svelte
+++ b/src/lib/components/ControlButton.svelte
@@ -13,9 +13,10 @@
     stage: ControlStage;
     onclick?: (event: MouseEvent) => void;
     ref?: HTMLButtonElement;
+    disabled?: boolean;
   }
 
-  let { stage, onclick, ref = $bindable() }: Props = $props();
+  let { stage, onclick, ref = $bindable(), disabled = false }: Props = $props();
 
   const icons: Record<ControlStage, string> = {
     [CONTROL_BUTTON_STATES.SETUP]: '◉',
@@ -30,6 +31,7 @@
   aria-label="Control Button"
   data-stage={stage}
   data-playing={stage === CONTROL_BUTTON_STATES.STOP}
+  {disabled}
   {onclick}
 >
   {icons[stage]}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -18,12 +18,12 @@
   <p>ERROR: GLaDOS voice was not found.</p>
   <p>Please select one of the provided replacement voices.</p>
   <p>Being content with the default selection is permissible.</p>
-  <div class="row">
-    <VoiceSelect
-      {voices}
-      onchange={onvoicechange}
-      onenabledchanged={(isDisabled) => (testDisabled = isDisabled)}
-    />
+  <VoiceSelect
+    {voices}
+    onchange={onvoicechange}
+    onenabledchanged={(isDisabled) => (testDisabled = isDisabled)}
+  />
+  <div class="test-row">
     <TestButton disabled={testDisabled} onclick={ontest} />
   </div>
   <p>
@@ -35,13 +35,13 @@
 
 <style>
   #settings {
-    .row {
+    display: flex;
+    flex-flow: column;
+    gap: 0.75rem;
+
+    .test-row {
       display: flex;
-      flex-flow: row wrap;
-
-      gap: 1rem;
-
-      justify-content: space-between;
+      justify-content: flex-end;
     }
   }
 </style>

--- a/src/lib/components/VoiceSelect.svelte
+++ b/src/lib/components/VoiceSelect.svelte
@@ -1,7 +1,25 @@
-<script lang="ts">
-  import { slugify } from '$lib/Utils';
+<script lang="ts" module>
+  const STORAGE_KEY = 'sams-still-alive:selected-voice-uri';
+  const TIER_RE = /\s*\((Premium|Enhanced|Compact|Eloquence)\)\s*$/i;
+</script>
 
-  type VoiceOption = { key: string; voice: SpeechSynthesisVoice };
+<script lang="ts">
+  import { browser } from '$app/environment';
+
+  type Tier = 'Premium' | 'Enhanced' | 'Compact' | 'Eloquence' | null;
+
+  type VoiceOption = {
+    key: string;
+    voice: SpeechSynthesisVoice;
+    displayName: string;
+    tier: Tier;
+    lang: string;
+    primaryLang: string;
+    langLabel: string;
+    primaryLangLabel: string;
+  };
+
+  type Group = { lang: string; label: string; options: VoiceOption[] };
 
   interface Props {
     voices: SpeechSynthesisVoice[];
@@ -11,79 +29,335 @@
 
   let { voices, onchange, onenabledchanged }: Props = $props();
 
-  let options = $derived.by<VoiceOption[]>(() =>
-    voices
-      .map((voice) => ({ key: slugify(voice.name), voice }))
-      .sort((a, b) => {
-        const byLang = a.voice.lang.localeCompare(b.voice.lang);
-        return byLang === 0 ? a.voice.name.localeCompare(b.voice.name) : byLang;
-      })
-  );
-
-  let longestNameLength = $derived(
-    options.reduce((max, o) => (o.voice.name.length > max ? o.voice.name.length : max), 0)
-  );
-
-  let isDisabled = $derived(options.length === 0);
+  let search = $state('');
+  let localOnly = $state(false);
+  let myLangOnly = $state(false);
   let selectedKey = $state('');
 
+  const myLang = browser ? (navigator.language.split('-')[0] || '').toLowerCase() : '';
+  const langDisplay = browser
+    ? new Intl.DisplayNames([navigator.language], { type: 'language' })
+    : null;
+  const regionDisplay = browser
+    ? new Intl.DisplayNames([navigator.language], { type: 'region' })
+    : null;
+
+  function labelForLang(tag: string, primaryOnly: boolean): string {
+    const [lang, region] = tag.split('-');
+    const langName = langDisplay?.of(lang) ?? lang;
+    if (primaryOnly || !region) return langName;
+    const regionName = regionDisplay?.of(region.toUpperCase()) ?? region;
+    return `${langName} (${regionName})`;
+  }
+
+  const options = $derived<VoiceOption[]>(
+    voices.map((voice) => {
+      const tierMatch = voice.name.match(TIER_RE);
+      const tier = (tierMatch ? tierMatch[1] : null) as Tier;
+      const displayName = tier ? voice.name.replace(TIER_RE, '').trim() : voice.name;
+      const primaryLang = (voice.lang.split('-')[0] || voice.lang).toLowerCase();
+      return {
+        key: voice.voiceURI,
+        voice,
+        displayName,
+        tier,
+        lang: voice.lang,
+        primaryLang,
+        langLabel: labelForLang(voice.lang, false),
+        primaryLangLabel: labelForLang(voice.lang, true)
+      };
+    })
+  );
+
+  const filtered = $derived.by(() => {
+    const q = search.trim().toLowerCase();
+    return options.filter((o) => {
+      if (localOnly && !o.voice.localService) return false;
+      if (myLangOnly && myLang && o.primaryLang !== myLang) return false;
+      if (!q) return true;
+      return (
+        o.displayName.toLowerCase().includes(q) ||
+        o.lang.toLowerCase().includes(q) ||
+        o.langLabel.toLowerCase().includes(q) ||
+        o.primaryLangLabel.toLowerCase().includes(q) ||
+        (o.tier?.toLowerCase().includes(q) ?? false)
+      );
+    });
+  });
+
+  const grouped = $derived.by<Group[]>(() => {
+    const byLang: Record<string, Group> = {};
+    for (const o of filtered) {
+      let g = byLang[o.primaryLang];
+      if (!g) {
+        g = { lang: o.primaryLang, label: o.primaryLangLabel, options: [] };
+        byLang[o.primaryLang] = g;
+      }
+      g.options.push(o);
+    }
+    const groups = Object.values(byLang);
+    for (const g of groups) {
+      g.options.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    }
+    return groups.sort((a, b) => a.label.localeCompare(b.label));
+  });
+
+  let isDisabled = $derived(options.length === 0);
+
+  let initialized = false;
   $effect(() => {
-    if (options.length === 0) {
-      selectedKey = '';
-      return;
+    if (initialized || options.length === 0) return;
+    initialized = true;
+    let stored: string | null = null;
+    if (browser) {
+      try {
+        stored = localStorage.getItem(STORAGE_KEY);
+      } catch {
+        stored = null;
+      }
     }
-    const stillExists = options.some((o) => o.key === selectedKey);
-    if (!stillExists) {
-      const def = options.find((o) => o.voice.default) ?? options[0];
-      selectedKey = def.key;
-    }
+    const fromStorage = stored ? options.find((o) => o.key === stored) : undefined;
+    const fallback = options.find((o) => o.voice.default) ?? options[0];
+    const pick = fromStorage ?? fallback;
+    selectedKey = pick.key;
+    onchange?.(pick.voice);
+  });
+
+  $effect(() => {
+    if (!selectedKey || options.length === 0) return;
+    if (options.some((o) => o.key === selectedKey)) return;
+    const fallback = options.find((o) => o.voice.default) ?? options[0];
+    selectedKey = fallback.key;
+    onchange?.(fallback.voice);
   });
 
   $effect(() => {
     onenabledchanged?.(isDisabled);
   });
 
-  function handleChange() {
-    const found = options.find((o) => o.key === selectedKey);
-    if (found) {
-      onchange?.(found.voice);
+  function persist(key: string) {
+    if (!browser) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, key);
+    } catch {
+      /* quota / privacy mode — ignore */
     }
+  }
+
+  function handleSelect(option: VoiceOption) {
+    selectedKey = option.key;
+    persist(option.key);
+    onchange?.(option.voice);
+  }
+
+  function jumpToDefault() {
+    const def = options.find((o) => o.voice.default);
+    if (def) handleSelect(def);
   }
 </script>
 
-<select
-  id="voice"
-  name="voice"
-  disabled={isDisabled}
-  bind:value={selectedKey}
-  onchange={handleChange}
->
+<div class="voice-select">
+  <div class="toolbar">
+    <input
+      type="search"
+      class="search"
+      placeholder="Search voices…"
+      bind:value={search}
+      disabled={isDisabled}
+      aria-label="Search voices"
+    />
+    <div class="chips" role="group" aria-label="Voice filters">
+      <label class="chip" class:active={localOnly}>
+        <input type="checkbox" bind:checked={localOnly} disabled={isDisabled} />
+        Local only
+      </label>
+      <label class="chip" class:active={myLangOnly} class:hidden={!myLang}>
+        <input type="checkbox" bind:checked={myLangOnly} disabled={isDisabled} />
+        My language
+      </label>
+      <button type="button" class="chip" onclick={jumpToDefault} disabled={isDisabled}>
+        ★ Default
+      </button>
+    </div>
+  </div>
+
   {#if options.length === 0}
-    <option>No Voices available on your System</option>
+    <p class="empty">No voices available on your system.</p>
+  {:else if grouped.length === 0}
+    <p class="empty">No voices match the current filters.</p>
   {:else}
-    {#each options as option (option.key)}
-      <option value={option.key}>
-        {option.voice.name.padEnd(longestNameLength, ' ')} ({option.voice.lang})
-      </option>
-    {/each}
+    <div class="list" role="radiogroup" aria-label="Voice">
+      {#each grouped as group (group.lang)}
+        <fieldset>
+          <legend>{group.label}</legend>
+          {#each group.options as option (option.key)}
+            <label class="row" class:selected={selectedKey === option.key}>
+              <input
+                type="radio"
+                name="voice"
+                value={option.key}
+                checked={selectedKey === option.key}
+                onchange={() => handleSelect(option)}
+              />
+              <span class="name">{option.displayName}</span>
+              {#if option.voice.default}
+                <span class="badge default" title="System default" aria-label="System default">★</span>
+              {/if}
+              {#if option.tier}
+                <span class="badge tier">{option.tier}</span>
+              {/if}
+              {#if !option.voice.localService}
+                <span class="badge net" title="Network voice">network</span>
+              {/if}
+              <span class="lang">{option.lang}</span>
+            </label>
+          {/each}
+        </fieldset>
+      {/each}
+    </div>
   {/if}
-</select>
+</div>
 
 <style>
-  #voice {
+  .voice-select {
+    flex: 1 1 100%;
+    display: flex;
+    flex-flow: column;
+    gap: 0.5rem;
     color: var(--amber);
+    min-width: 0;
+  }
 
+  .toolbar {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  .search {
+    flex: 1 1 12rem;
+    min-width: 0;
     height: 2rem;
-    font-family: var(--font-family);
-    line-height: 2rem;
-    flex-grow: 1;
-
+    padding: 0 0.5rem;
+    color: var(--amber);
+    background: var(--background);
     border: 1px solid var(--amber);
     border-radius: 4px;
-    background: var(--background);
+    font-family: var(--font-family);
+  }
+  .search:focus { outline: var(--amber); }
+  .search:disabled {
+    color: var(--disabled);
+    border-color: var(--disabled);
+    border-style: dashed;
+  }
 
-    &:focus {
-      outline: var(--amber);
-    }
+  .chips {
+    display: flex;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.1rem 0.6rem;
+    border: 1px solid var(--amber);
+    border-radius: 999px;
+    background: var(--background);
+    color: var(--amber);
+    font-family: var(--font-family);
+    font-size: 0.85rem;
+    line-height: 1.6;
+    cursor: pointer;
+    user-select: none;
+  }
+  .chip.active {
+    background: color-mix(in srgb, var(--amber) 25%, transparent);
+  }
+  .chip input[type="checkbox"] {
+    accent-color: var(--amber);
+    margin: 0;
+  }
+  .chip:disabled,
+  .chip:has(input:disabled) {
+    color: var(--disabled);
+    border-color: var(--disabled);
+    border-style: dashed;
+    cursor: default;
+  }
+
+  .list {
+    max-height: 18rem;
+    overflow-y: auto;
+    border: 1px solid var(--amber);
+    border-radius: 4px;
+    padding: 0.25rem;
+  }
+
+  fieldset {
+    border: none;
+    border-top: 1px dashed var(--amber);
+    margin: 0;
+    padding: 0.25rem 0;
+    min-width: 0;
+  }
+  fieldset:first-of-type { border-top: none; }
+  legend {
+    padding: 0 0.25rem;
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto auto auto;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.2rem 0.5rem;
+    cursor: pointer;
+    border-radius: 2px;
+  }
+  .row:hover { background: color-mix(in srgb, var(--amber) 12%, transparent); }
+  .row.selected { background: color-mix(in srgb, var(--amber) 22%, transparent); }
+  .row input[type="radio"] { accent-color: var(--amber); margin: 0; }
+
+  .name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .lang {
+    opacity: 0.7;
+    font-size: 0.8rem;
+    justify-self: end;
+    font-variant-numeric: tabular-nums;
+  }
+  .badge {
+    border: 1px solid var(--amber);
+    border-radius: 3px;
+    padding: 0 0.3rem;
+    font-size: 0.7rem;
+    line-height: 1.4;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .badge.default {
+    border: none;
+    padding: 0;
+    font-size: 1rem;
+    line-height: 1;
+  }
+  .badge.net {
+    opacity: 0.7;
+  }
+
+  .empty {
+    opacity: 0.7;
+    padding: 0.5rem;
+    margin: 0;
   }
 </style>

--- a/src/lib/components/VoiceSelect.svelte
+++ b/src/lib/components/VoiceSelect.svelte
@@ -51,22 +51,27 @@
   }
 
   const options = $derived<VoiceOption[]>(
-    voices.map((voice) => {
-      const tierMatch = voice.name.match(TIER_RE);
-      const tier = (tierMatch ? tierMatch[1] : null) as Tier;
-      const displayName = tier ? voice.name.replace(TIER_RE, '').trim() : voice.name;
-      const primaryLang = (voice.lang.split('-')[0] || voice.lang).toLowerCase();
-      return {
-        key: voice.voiceURI,
-        voice,
-        displayName,
-        tier,
-        lang: voice.lang,
-        primaryLang,
-        langLabel: labelForLang(voice.lang, false),
-        primaryLangLabel: labelForLang(voice.lang, true)
-      };
-    })
+    voices
+      .map((voice) => {
+        const tierMatch = voice.name.match(TIER_RE);
+        const tier = (tierMatch ? tierMatch[1] : null) as Tier;
+        const displayName = tier ? voice.name.replace(TIER_RE, '').trim() : voice.name;
+        const primaryLang = (voice.lang.split('-')[0] || voice.lang).toLowerCase();
+        return {
+          key: voice.voiceURI,
+          voice,
+          displayName,
+          tier,
+          lang: voice.lang,
+          primaryLang,
+          langLabel: labelForLang(voice.lang, false),
+          primaryLangLabel: labelForLang(voice.lang, true)
+        };
+      })
+      .sort((a, b) => {
+        const byLang = a.primaryLangLabel.localeCompare(b.primaryLangLabel);
+        return byLang === 0 ? a.displayName.localeCompare(b.displayName) : byLang;
+      })
   );
 
   const filtered = $derived.by(() => {
@@ -104,10 +109,19 @@
 
   let isDisabled = $derived(options.length === 0);
 
-  let initialized = false;
+  let userPicked = false;
   $effect(() => {
-    if (initialized || options.length === 0) return;
-    initialized = true;
+    if (options.length === 0) {
+      selectedKey = '';
+      return;
+    }
+    if (userPicked) {
+      if (options.some((o) => o.key === selectedKey)) return;
+      const fallback = options.find((o) => o.voice.default) ?? options[0];
+      selectedKey = fallback.key;
+      onchange?.(fallback.voice);
+      return;
+    }
     let stored: string | null = null;
     if (browser) {
       try {
@@ -119,16 +133,9 @@
     const fromStorage = stored ? options.find((o) => o.key === stored) : undefined;
     const fallback = options.find((o) => o.voice.default) ?? options[0];
     const pick = fromStorage ?? fallback;
+    if (pick.key === selectedKey) return;
     selectedKey = pick.key;
     onchange?.(pick.voice);
-  });
-
-  $effect(() => {
-    if (!selectedKey || options.length === 0) return;
-    if (options.some((o) => o.key === selectedKey)) return;
-    const fallback = options.find((o) => o.voice.default) ?? options[0];
-    selectedKey = fallback.key;
-    onchange?.(fallback.voice);
   });
 
   $effect(() => {
@@ -145,6 +152,7 @@
   }
 
   function handleSelect(option: VoiceOption) {
+    userPicked = true;
     selectedKey = option.key;
     persist(option.key);
     onchange?.(option.voice);
@@ -246,7 +254,10 @@
     border-radius: 4px;
     font-family: var(--font-family);
   }
-  .search:focus { outline: var(--amber); }
+  .search:focus-visible {
+    outline: 2px solid var(--amber);
+    outline-offset: 2px;
+  }
   .search:disabled {
     color: var(--disabled);
     border-color: var(--disabled);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,6 +27,9 @@
   let instructionsVisible = $derived(stage === CONTROL_BUTTON_STATES.SETUP);
   let settingsVisible = $derived(stage === CONTROL_BUTTON_STATES.PLAY);
   let terminalVisible = $derived(stage === CONTROL_BUTTON_STATES.STOP);
+  let controlDisabled = $derived(
+    stage === CONTROL_BUTTON_STATES.PLAY && preloadState !== 'ready'
+  );
 
   onMount(() => {
     if (!browser) return;
@@ -96,7 +99,12 @@
   <Header />
   <main>
     <div class="controls">
-      <ControlButton {stage} bind:ref={controlRef} onclick={handleControl} />
+      <ControlButton
+        {stage}
+        bind:ref={controlRef}
+        disabled={controlDisabled}
+        onclick={handleControl}
+      />
     </div>
     <Instructions visible={instructionsVisible} />
     <Settings

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,7 +28,7 @@
   let settingsVisible = $derived(stage === CONTROL_BUTTON_STATES.PLAY);
   let terminalVisible = $derived(stage === CONTROL_BUTTON_STATES.STOP);
   let controlDisabled = $derived(
-    stage === CONTROL_BUTTON_STATES.PLAY && preloadState !== 'ready'
+    stage === CONTROL_BUTTON_STATES.PLAY && preloadState === 'loading'
   );
 
   onMount(() => {


### PR DESCRIPTION
## Summary

Quality + UX pass after PR #24:

- **`fix(caroline)`** — Parts/Synths were never disposed, so each STOP→PLAY cycle stacked a fresh set of voices on the audio graph. Now tracked, disposed, and `await Tone.start()` is called before `Transport.start()` to handle Safari's autoplay policy.
- **`feat(voice-select)`** — flat `<select>` rebuilt as a picker panel with search, filter chips (Local only, My language, jump-to-default), language grouping via `<fieldset>` + `Intl.DisplayNames`, per-row badges (system default ★, quality tier, network), and `localStorage` persistence keyed by `voiceURI`.
- **`feat(ui)`** — control button is disabled while the audio engine is preloading.
- **`refactor(types)`** — vendored `NoteJSON` locally to drop the fragile `@tonejs/midi/dist/Note` deep import.
- **`chore(sam)`** — removed unused `_voices` instance field.

Also: research pass (not in this PR) confirmed `@tonejs/midi` is still the right choice in 2026; alternatives are either lower-level wrappers around the same parser, aimed at live MIDI I/O, or worse-fitting (flat event streams).

## Test plan

- [ ] `pnpm check` — passes
- [ ] `pnpm lint` — passes
- [ ] `pnpm build` — passes
- [ ] Manual: SETUP → wait for "Loading audio engine" → PLAY (button stays disabled while preloading)
- [ ] Manual: STOP then PLAY again — no audio doubling, no stuck synths
- [ ] Manual: voice picker shows grouped voices on macOS (Safari/Vivaldi) with star on default voice
- [ ] Manual: search "english" / "premium" / "en-GB" each narrow the list
- [ ] Manual: select a voice, reload — same voice is restored from localStorage
- [ ] Manual: Test button still previews the currently selected voice